### PR TITLE
v0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # reggie
 A small wrapper over Go's std [Registry](https://pkg.go.dev/golang.org/x/sys/windows/registry) package.
+[![Go Reference](https://pkg.go.dev/badge/pkg.go.dev/github.com/Xeckt/reggie.svg)](https://pkg.go.dev/pkg.go.dev/github.com/Xeckt/reggie)
 
 # Why?
 Through working on various personal projects heavily related to Windows, some of the standard functions

--- a/README.md
+++ b/README.md
@@ -3,15 +3,12 @@ A small wrapper over Go's std [Registry](https://pkg.go.dev/golang.org/x/sys/win
 
 [![Go Reference](https://pkg.go.dev/badge/pkg.go.dev/github.com/Xeckt/reggie.svg)](https://pkg.go.dev/github.com/Xeckt/reggie)
 
-# Why?
+# Summary
 Through working on various personal projects heavily related to Windows, some of the standard functions
 did not extend or perform the way I needed them to. Being low level, I was missing some handy behaviour I had
 to end up writing myself.
 
 The aim is not to over-complicate the usage, but make it small, simple, and apply more readability to the code.
-
-It can only search through one level of `subkeys` from a given `key`, however, I aim to add the behaviour of crawling
-multiple levels of registry subkeys.
 
 Still in development, don't expect it to be perfect.
 # How to use
@@ -34,5 +31,21 @@ for key, subkey := range r.SubKeys {
 	fmt.Println(key, subkey.Value)
 }
 ```
-
+The above usage example is basic. There are many ways to utilise reggie, one of them being subkey interaction
+like a normal `registry.Key`. Let's take the subkey `TeamViewer`, which we first enumerate from `HKLM\LOCAL_MACHINE` on subkey path `SOFTWARE`
+```go
+r := reggie.New()
+r.RootKey = registry.LOCAL_MACHINE
+r.Path = `SOFTWARE`
+err := r.GetKeysValues()
+if err != nil {
+	log.Fatal(err)
+}
+teamviewerKey, err := r.SubKeys["TeamViewer"].OpenKey()
+if err != nil {
+	log.Fatal(err)
+}
+fmt.Println(teamviewerKey.Value["Version"])
+fmt.Println(teamviewerKey.Key.Path)
+```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # reggie
 A small wrapper over Go's std [Registry](https://pkg.go.dev/golang.org/x/sys/windows/registry) package.
+
 [![Go Reference](https://pkg.go.dev/badge/pkg.go.dev/github.com/Xeckt/reggie.svg)](https://pkg.go.dev/pkg.go.dev/github.com/Xeckt/reggie)
 
 # Why?

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # reggie
-A small wrapper over Go's std [Registry](https://pkg.go.dev/golang.org/x/sys/windows/registry) package.
+A small wrapper over Go's std [registry](https://pkg.go.dev/golang.org/x/sys/windows/registry) package.
 
 [![Go Reference](https://pkg.go.dev/badge/pkg.go.dev/github.com/Xeckt/reggie.svg)](https://pkg.go.dev/github.com/Xeckt/reggie)
 
 # Summary
-Through working on various personal projects heavily related to Windows, some of the standard functions
+Through working on various personal projects heavily reliant to Windows, some of the standard functions of Go's [registry](https://pkg.go.dev/golang.org/x/sys/windows/registry)
 did not extend or perform the way I needed them to. Being low level, I was missing some handy behaviour I had
 to end up writing myself.
+There is a lot of manual behaviour necessary to write if you're only using the std registry package for your project which can become
+overbearing and difficult to track, whereas
+reggie will help ease the process of access and usage. It will (hopefully) help track the confusion of registry in your codebase.
 
-The aim is not to over-complicate the usage, but make it small, simple, and apply more readability to the code.
+The aim is to make it small, simple, and applicable for code readability.
 
-Still in development, don't expect it to be perfect.
 # How to use
 First get the package
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A small wrapper over Go's std [registry](https://pkg.go.dev/golang.org/x/sys/win
 [![Go Reference](https://pkg.go.dev/badge/pkg.go.dev/github.com/Xeckt/reggie.svg)](https://pkg.go.dev/github.com/Xeckt/reggie)
 
 # Summary
-Through working on various personal projects heavily reliant to Windows, some of the standard functions of Go's [registry](https://pkg.go.dev/golang.org/x/sys/windows/registry)
+Through working on various personal projects heavily reliant to Windows, some of the standard functions of [Go's registry](https://pkg.go.dev/golang.org/x/sys/windows/registry)
 did not extend or perform the way I needed them to. Being low level, I was missing some handy behaviour I had
 to end up writing myself.
 There is a lot of manual behaviour necessary to write if you're only using the std registry package for your project which can become

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # reggie
 A small wrapper over Go's std [Registry](https://pkg.go.dev/golang.org/x/sys/windows/registry) package.
 
-[![Go Reference](https://pkg.go.dev/badge/pkg.go.dev/github.com/Xeckt/reggie.svg)](pkg.go.dev/github.com/Xeckt/reggie)
+[![Go Reference](https://pkg.go.dev/badge/pkg.go.dev/github.com/Xeckt/reggie.svg)](https://pkg.go.dev/github.com/Xeckt/reggie)
 
 # Why?
 Through working on various personal projects heavily related to Windows, some of the standard functions

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # reggie
 A small wrapper over Go's std [Registry](https://pkg.go.dev/golang.org/x/sys/windows/registry) package.
 
-[![Go Reference](https://pkg.go.dev/badge/pkg.go.dev/github.com/Xeckt/reggie.svg)](https://pkg.go.dev/pkg.go.dev/github.com/Xeckt/reggie)
+[![Go Reference](https://pkg.go.dev/badge/pkg.go.dev/github.com/Xeckt/reggie.svg)](pkg.go.dev/github.com/Xeckt/reggie)
 
 # Why?
 Through working on various personal projects heavily related to Windows, some of the standard functions

--- a/reg_test.go
+++ b/reg_test.go
@@ -11,7 +11,7 @@ var (
 )
 
 func TestReg_EnumerateSubKeys(t *testing.T) {
-	r.Key = registry.CURRENT_CONFIG
+	r.RootKey = registry.CURRENT_CONFIG
 	r.Path = `System`
 	want := "CurrentControlSet"
 	got, err := r.EnumerateSubKeys(1)
@@ -24,10 +24,10 @@ func TestReg_EnumerateSubKeys(t *testing.T) {
 }
 
 func TestReg_GetValueFromType(t *testing.T) {
-	r.Key = registry.LOCAL_MACHINE
+	r.RootKey = registry.LOCAL_MACHINE
 	r.Path = `SYSTEM\CurrentControlSet\Control`
 	subKey := `CurrentUser`
-	key, err := registry.OpenKey(r.Key, r.Path, registry.ALL_ACCESS)
+	key, err := registry.OpenKey(r.RootKey, r.Path, registry.ALL_ACCESS)
 	if err != nil {
 		t.Error("Could not open subkey", r.Path, "Error:", err)
 	}
@@ -42,7 +42,7 @@ func TestReg_GetValueFromType(t *testing.T) {
 }
 
 func TestReg_GetSubKeysValues(t *testing.T) {
-	r.Key = registry.LOCAL_MACHINE
+	r.RootKey = registry.LOCAL_MACHINE
 	r.Path = `SYSTEM\CurrentControlSet`
 	err := r.GetSubKeysValues()
 	if err != nil {

--- a/reg_test.go
+++ b/reg_test.go
@@ -44,7 +44,7 @@ func TestReg_GetValueFromType(t *testing.T) {
 func TestReg_GetSubKeysValues(t *testing.T) {
 	r.RootKey = registry.LOCAL_MACHINE
 	r.Path = `SYSTEM\CurrentControlSet`
-	err := r.GetSubKeysValues()
+	err := r.GetKeysValues()
 	if err != nil {
 		t.Error(err)
 	}

--- a/reggie.go
+++ b/reggie.go
@@ -2,16 +2,14 @@ package reggie
 
 import (
 	"errors"
-	"fmt"
 	"golang.org/x/sys/windows/registry"
 )
 
 type Reg struct {
-	RootKey     registry.Key       // The key in which to access (HKLM, HKCU, etc). Can also be a subkey
-	Path        string             // The path inside RootKey to use
-	Access      uint32             // The access type for given RootKey and Path
-	CurrOpenKey registry.Key       // The key currently opened
-	SubKeys     map[string]*SubKey // Holds the subkeys underneath RootKey
+	RootKey    registry.Key       // The key in which to access (HKLM, HKCU, etc). Can also be a subkey
+	Path       string             // The path inside RootKey to use
+	Permission uint32             // The access type for given RootKey and Path
+	SubKeys    map[string]*SubKey // Holds the subkeys underneath RootKey
 }
 
 type SubKey struct {
@@ -19,59 +17,65 @@ type SubKey struct {
 	Value map[string]any // Holds the key value data stored in each subkey.
 }
 
-func (s SubKey) GetKey() *Reg { return s.Key }
-
-func (s SubKey) GetValue(name string) any { return s.Value[name] }
+// OpenKey is used to open a subkey in the Reg SubKeys map and return the new subkey as an object for interaction.
+func (s SubKey) OpenKey() (SubKey, error) {
+	k, err := registry.OpenKey(s.Key.RootKey, s.Key.Path, s.Key.Permission)
+	if err != nil {
+		return s, err
+	}
+	s.Key.RootKey = k
+	return s, nil
+}
 
 // New initialises a Reg struct with ALL_ACCESS permissions. Better used for testing unless requirements demand it.
 func New() *Reg {
 	return &Reg{
-		Access:  registry.ALL_ACCESS,
-		SubKeys: make(map[string]*SubKey),
+		Permission: registry.ALL_ACCESS,
+		SubKeys:    make(map[string]*SubKey),
 	}
 }
 
-// GetSubKeysValues obtains RootKey, enumerates through each subkey in given Path, and obtains each non-empty value attached within every subkey.
-// When successful, each subkey will be attached to *Reg.SubKeys and each subkeys key=value pair in *Reg.SubKeys[k].Value
-func (r *Reg) GetSubKeysValues() error {
+// GetKeysValues obtains RootKey, enumerates through each subkey in given Path. Each subkey will be attached inside Reg.SubKeys
+// with its relevant data.
+func (r *Reg) GetKeysValues() error {
 	s, err := r.EnumerateSubKeys()
 	if err != nil {
 		return err
 	}
 	for _, subkey := range s {
 		p := r.Path + "\\" + subkey
-		key, err := registry.OpenKey(r.RootKey, p, r.Access) // Must open each subkey as a new key
+		key, err := registry.OpenKey(r.RootKey, p, r.Permission) // Must open each subkey as a new key
 		if err != nil {
-			fmt.Println(subkey, r.Path, err)
 			return err
+		}
+		if r.SubKeys[subkey] == nil {
+			r.SubKeys[subkey] = &SubKey{
+				Key:   &Reg{},
+				Value: map[string]any{},
+			}
 		}
 		names, err := key.ReadValueNames(0)
 		if err != nil {
 			return err
 		}
-		for _, name := range names {
-			if r.SubKeys[subkey] == nil {
-				r.SubKeys[subkey] = &SubKey{
-					Value: map[string]any{}, // Create a blank value map
-				}
+		for _, n := range names {
+			value, err := r.GetValueFromType(key, n)
+			if err != nil {
+				return err
 			}
-			value, _ := r.GetValueFromType(key, name)
-			if len(name) != 0 {
-				r.SubKeys[subkey].Key.RootKey = key // Allow for an interactable subkey object inside each subkey map
-				r.SubKeys[subkey].Key.Path = p
-				r.SubKeys[subkey].Value[name] = value
-			}
+			r.SubKeys[subkey].Value[n] = value
 		}
+		r.SubKeys[subkey].Key.RootKey = key // Allow for an interactive subkey object inside each subkey map
+		r.SubKeys[subkey].Key.Path = p
+		r.SubKeys[subkey].Key.Permission = r.Permission
 	}
 	return nil
 }
 
 // GetValueFromType takes a specified registry key and returns the value of the named key `n`
 func (r *Reg) GetValueFromType(k registry.Key, n string) (any, error) {
-	_, t, err := k.GetValue(n, nil)
-	if err != nil {
-		return nil, err
-	}
+	var err error
+	_, t, _ := k.GetValue(n, nil)
 	var v any
 	switch t {
 	case registry.NONE:
@@ -88,10 +92,10 @@ func (r *Reg) GetValueFromType(k registry.Key, n string) (any, error) {
 	case registry.MULTI_SZ:
 		v, _, err = k.GetStringsValue(n)
 	}
-	if v != nil {
-		return v, nil
+	if err != nil {
+		return nil, err
 	}
-	return v, err
+	return v, nil
 }
 
 // EnumerateSubKeys takes the given key in the Reg struct, enumerate


### PR DESCRIPTION
There were bugs in the GetKeysValues() function:
- Not grabbing all key data names inside subkey
- Not assigning all values to data names inside subkey

I have removed the requirement of only grabbing non empty keys in this function, as lots of top level subkeys are empty but have child subkeys that have data. This doesn't change how the function returns it's information.

Additions:
- Can now interact with subkeys as a normal `registry.Key` + information from it's mapped `Reg` struct