### PR TITLE
v0.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,18 @@ if err != nil {
 }
 fmt.Println(s.SubKeys) // Returns a map of the subkeys you can use as normal registry.Key objects
 ```
+A prominent feature of reggie is the `Traverse()` function. Sometimes you don't know what you're looking for, or you may have dynamic
+data you need to handle. Traverse helps you write your own magic:
+```go
+err = reggie.Traverse(r, false, func(reg *reggie.Reg) {
+	if strings.Contains(reg.Path, "QNAP") {
+		fmt.Println(reg.Path)
+		return
+	}
+})
+```
+Something that reggie doesn't provide yet, is the handling of the errors that are under the hood in the `registry` package. Because the traversal can start
+from the bottom up or the up down, you may experience different results each time it's run. So running the same code above may result in error one time and not another. 
+This is also rather complicated considering the errors are inherently returned by Windows, so a lot of string magic needs to happen.
+
+A solution to this is being worked on currently.

--- a/README.md
+++ b/README.md
@@ -1,75 +1,87 @@
 # reggie
+[![Go Reference](https://pkg.go.dev/badge/pkg.go.dev/github.com/Xeckt/reggie.svg)](https://pkg.go.dev/github.com/Xeckt/reggie)
 A small wrapper over Go's std [registry](https://pkg.go.dev/golang.org/x/sys/windows/registry) package.
 
 Documentation and examples are available here: [Documentation](#Documentation)
 # Summary
-[Go's registry package](https://pkg.go.dev/golang.org/x/sys/windows/registry) becomes a bit tedious when handling
-a lot of keys inside the registry at once, and fetching data from them. 
+[Go's registry package](https://pkg.go.dev/golang.org/x/sys/windows/registry) is extremely useful but limitations arise where
+you have a wider range of requirements, thus requiring customised functions to handle the use case. 
 
-So, reggie helps handle situations where you are dealing with larger sets of registry data.
+Reggie assists on that front and gives you wider, structured utilities and access for handling the registry.
 
 # Using Reggie
 ```
 go get github.com/Xeckt/reggie
 ```
 
-# Documentation
-[![Go Reference](https://pkg.go.dev/badge/pkg.go.dev/github.com/Xeckt/reggie.svg)](https://pkg.go.dev/github.com/Xeckt/reggie)
-
-You usually start by defining a `Reggie.Reg` struct object, either with the `New()` func or by populating the struct yourself.
-It uses the same format as the [registry](https://pkg.go.dev/golang.org/x/sys/windows/registry) package with minor additions.
+# Examples
+Let's take an example where you want to access a *set* of registry keys, in the std package, it would look like:
 ```go
-r := reggie.New()
-r.Key = registry.LOCAL_MACHINE
-r.Path = `System\CurrentControlSet`
-```
-From here you have few options. Reggie can enumerate through the subkey names for you such as the provided location above, but we will take advantage
-of the `GetSubKeysValues()` function. Which will populate the `SubKeys` map in our struct with the specified registry locations
-key data.
-```go
-err := r.GetSubKeysValues()
-if err != nil {
-	log.Fatal(err)
-}
-for key, subkey := range r.SubKeys {
-    fmt.Println(key, subkey.Value)
-}
-```
-If you know what you're looking for specifically, you have a few approaches, and reggie still allows you to utilise the [std registry package functions](https://pkg.go.dev/golang.org/x/sys/windows/registry):
-```go
-r := reggie.New()
-r.RootKey = registry.LOCAL_MACHINE
-r.Path = `SOFTWARE`
-err := r.GetKeysValues() // Populate the struct
-if err != nil {
-	log.Fatal(err)
-}
-teamviewer := r.SubKeys["TeamViewer"] // Utilise the teamviewer subkey
-fmt.Println(teamviewer.Value["Version"]) // Reggie's version of accessing values
-fmt.Println(teamviewer.Key.OpenedKey.GetStringValue("Version")) // Default way of the registry package
-```
-We could take this a step further by trailing into `TeamViewer` subkeys as well, by taking advantage of the `OpenKey(bool)` function
-and setting its parameter to true, otherwise it creates an empty subkey map for you to handle while keeping related key objects. Useful when you are
-handling situations where string magic is necessary:
-```go
-s, err := r.SubKeys["TeamViewer"].OpenKey(true)
-if err != nil {
-	log.Fatal(err)
-}
-fmt.Println(s.SubKeys) // Returns a map of the subkeys you can use as normal registry.Key objects
-```
-A prominent feature of reggie is the `Traverse()` function. Sometimes you don't know what you're looking for, or you may have dynamic
-data you need to handle. This function will recursively traverse the tree below a given `Key`. It helps you write your own magic:
-```go
-err = reggie.Traverse(r, false, func(reg *reggie.Reg) {
-	if strings.Contains(reg.Path, "QNAP") {
-		fmt.Println(reg.Path)
-		return
+func main() {
+	key, _, err := registry.CreateKey(registry.CURRENT_USER, `Control Panel`, registry.ALL_ACCESS)
+	if err != nil {
+		log.Fatal(err)
 	}
-})
+	subkeys, err := key.ReadSubKeyNames(0)
+	for _, subkey := range subkeys {
+		key, _, err := registry.CreateKey(registry.CURRENT_USER, `Control Panel\`+subkey, registry.ALL_ACCESS)
+		if err != nil {
+			log.Fatal(err)
+		}
+		moreKeys, err := key.ReadSubKeyNames(0)
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, k := range moreKeys {
+			fmt.Println(subkey, "->", k)
+		}
+	}
+}
 ```
-Something that reggie doesn't provide yet, is the handling of the errors that are under the hood in the `registry` package. Because the traversal can start
-from the bottom up or the up down, you may experience different results each time it's run. So running the same code above may result in error one time and not another. 
-This is also rather complicated considering the errors are inherently returned by Windows, so a lot of string magic needs to happen.
-
-A solution to this is being worked on currently.
+It's quite something, additionally you would need to add your own magic. We will use `reggie` to do the exact same as the above:
+```go
+func main() {
+	r := reggie.NewReg(registry.ALL_ACCESS)
+	r.RootKey = registry.CURRENT_USER
+	r.Path = `Control Panel`
+	err := r.GetKeysValues() // Reggie will populate its own structs
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = r.SubKeyMap["Accessibility"].Data.GetKeysValues()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("Control panel subkeys -> ", r.SubKeyMap, "\nControl Panel - Accessibility Subkeys ->",
+		r.SubKeyMap["Accessibility"].Data)
+}
+```
+If we wanted to shorten that further, `reggie` has a recursive function `Traverse()`, which allows you to do bulk actions:
+```go
+func main() {
+	r := reggie.NewReg(registry.ALL_ACCESS)
+	r.RootKey = registry.CURRENT_USER
+	r.Path = `Control Panel`
+	err := r.GetKeysValues() // Reggie will populate its own structs
+	if err != nil {
+		log.Fatal(err)
+	}
+	reggie.Traverse(r, true, func(reg *reggie.Reg) {
+		for key, value := range reg.SubKeyMap {
+            fmt.Println(reg.Path, "->", key, value)
+		}
+	})
+}
+```
+Given the registry path above, output would look like:
+```
+Control Panel\Accessibility -> ToggleKeys &{0xc0003fd620 map[Flags:62]}
+Control Panel\Accessibility -> HighContrast &{0xc0003fce40 map[Flags:126 High Contrast Scheme: Previous High Contrast Scheme MUI Value:]}
+Control Panel\Accessibility -> On &{0xc0003fd1a0 map[Locale:0 On:0]}
+Control Panel\Accessibility -> SlateLaunch &{0xc0003fd320 map[ATapp:narrator LaunchAT:1]}
+Control Panel\Accessibility -> Blind Access &{0xc0003fcd80 map[On:0]}
+Control Panel\Accessibility -> ShowSounds &{0xc0003fd260 map[On:0]}
+Control Panel\Accessibility -> SoundSentry &{0xc0003fd3e0 map[FSTextEffect:0 Flags:2 TextEffect:0 WindowsEffect:1]}
+Control Panel\Accessibility -> Keyboard Preference &{0xc0003fcf30 map[On:0]}
+...
+```

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ func main() {
 	r := reggie.NewReg(registry.ALL_ACCESS)
 	r.RootKey = registry.CURRENT_USER
 	r.Path = `Control Panel`
-	err := r.GetKeysValues() // Reggie will populate its own structs
+	err := r.GetKeysValues()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/README.md
+++ b/README.md
@@ -86,3 +86,22 @@ Control Panel\Accessibility -> SoundSentry &{0xc0003fd3e0 map[FSTextEffect:0 Fla
 Control Panel\Accessibility -> Keyboard Preference &{0xc0003fcf30 map[On:0]}
 ...
 ```
+Similarly, you may want to create keys. reggie handles this situation dynamically. Let's say you wanted to create a new subkey
+under `HKCU\Control Panel\Accessibility`:
+```go
+func main() {
+	r := reggie.NewReg(registry.ALL_ACCESS)
+	r.RootKey = registry.CURRENT_USER
+	r.Path = `Control Panel`
+	err := r.GetKeysValues()
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = r.SubKeyMap["Accessibility"].Data.CreateKey("NewKey")
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```
+If you wanted to `GetKeysValues` on the `Accessibility` key beforehand, then create one, reggie will automatically populate
+your struct with the new key as well, therefore, you have no need to manually reassign back into your struct.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # reggie
 [![Go Reference](https://pkg.go.dev/badge/pkg.go.dev/github.com/Xeckt/reggie.svg)](https://pkg.go.dev/github.com/Xeckt/reggie)
+
 A small wrapper over Go's std [registry](https://pkg.go.dev/golang.org/x/sys/windows/registry) package.
 
 Documentation and examples are available here: [Documentation](#Documentation)

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ If you know what you're looking for specifically, you have a few approaches, and
 r := reggie.New()
 r.RootKey = registry.LOCAL_MACHINE
 r.Path = `SOFTWARE`
-err := r.GetKeysValues()
+err := r.GetKeysValues() // Populate the struct
 if err != nil {
 	log.Fatal(err)
 }
-teamviewer := r.SubKeys["TeamViewer"]
-fmt.Println(teamviewer.Value["Version"])
-fmt.Println(teamviewer.Key.OpenedKey.GetStringValue("Version"))
+teamviewer := r.SubKeys["TeamViewer"] // Utilise the teamviewer subkey
+fmt.Println(teamviewer.Value["Version"]) // Reggie's version of accessing values
+fmt.Println(teamviewer.Key.OpenedKey.GetStringValue("Version")) // Default way of the registry package
 ```
 We could take this a step further by trailing into `TeamViewer` subkeys as well, by taking advantage of the `OpenKey(bool)` function
 and setting its parameter to true, otherwise it creates an empty subkey map for you to handle while keeping related key objects. Useful when you are

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ if err != nil {
 fmt.Println(s.SubKeys) // Returns a map of the subkeys you can use as normal registry.Key objects
 ```
 A prominent feature of reggie is the `Traverse()` function. Sometimes you don't know what you're looking for, or you may have dynamic
-data you need to handle. Traverse helps you write your own magic:
+data you need to handle. This function will recursively traverse the tree below a given `Key`. It helps you write your own magic:
 ```go
 err = reggie.Traverse(r, false, func(reg *reggie.Reg) {
 	if strings.Contains(reg.Path, "QNAP") {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/Xeckt/reggie
 
-go 1.20
+go 1.21
 
 require golang.org/x/sys v0.10.0

--- a/reg_test.go
+++ b/reg_test.go
@@ -2,68 +2,8 @@ package reggie
 
 import (
 	"golang.org/x/sys/windows/registry"
-	"strings"
-	"testing"
 )
 
 var (
-	r = New()
+	r = NewReg(registry.ALL_ACCESS)
 )
-
-func TestReg_EnumerateSubKeys(t *testing.T) {
-	r.RootKey = registry.CURRENT_CONFIG
-	r.Path = `System`
-	want := "CurrentControlSet"
-	got, err := r.EnumerateSubKeys(1)
-	if err != nil {
-		t.Error(err)
-	}
-	if !strings.EqualFold(want, got[0]) {
-		t.Error("Expected:", want, "Received:", got)
-	}
-}
-
-func TestReg_GetValueFromType(t *testing.T) {
-	r.RootKey = registry.LOCAL_MACHINE
-	r.Path = `SYSTEM\CurrentControlSet\Control`
-	subKey := `CurrentUser`
-	key, err := registry.OpenKey(r.RootKey, r.Path, registry.ALL_ACCESS)
-	if err != nil {
-		t.Error("Could not open subkey", r.Path, "Error:", err)
-	}
-	got, err := r.GetValueFromType(key, subKey)
-	if err != nil {
-		t.Error(err)
-	}
-	want := "USERNAME"
-	if want != got {
-		t.Error("Expected:", want, "Received:", got)
-	}
-}
-
-func TestReg_GetSubKeysValues(t *testing.T) {
-	r.RootKey = registry.LOCAL_MACHINE
-	r.Path = `SYSTEM\CurrentControlSet`
-	err := r.GetKeysValues()
-	if err != nil {
-		t.Error(err)
-	}
-	want := []string{"Control", "CurrentUser", "USERNAME"}
-	received := []string{}
-
-	for subkey, keys := range r.SubKeys {
-		for key, value := range keys.Value {
-			if strings.EqualFold(want[0], subkey) &&
-				strings.EqualFold(want[1], key) &&
-				strings.EqualFold(want[2], value.(string)) {
-				received = append(received, subkey, key, value.(string))
-				break
-			}
-		}
-	}
-	for i, v := range want {
-		if v != received[i] {
-			t.Error("Received:", received[i], "Wanted:", v)
-		}
-	}
-}

--- a/reggie.go
+++ b/reggie.go
@@ -3,7 +3,6 @@
 package reggie
 
 import (
-	"errors"
 	"fmt"
 	"golang.org/x/sys/windows/registry"
 	"strings"
@@ -218,25 +217,17 @@ func (r *Reg) CreateValue(key string, value any, valueType uint32) error {
 // and find it's subkeys. Amount specifies how many subkeys you want to enumerate.
 // The default value is 0 to enumerate all within a given key, anything above 0 will enumerate to the specified amount.
 // Amount cannot have more than one element. Behaves the same as specified in registry documentation: https://pkg.go.dev/golang.org/x/sys/windows/registry#Key.ReadSubKeyNames
-func (r *Reg) EnumerateSubKeys(amount ...int) ([]string, error) {
-	if len(amount) > 1 {
-		return nil, errors.New("length of amount cannot exceed 1")
-	}
-
+func (r *Reg) EnumerateSubKeys(amount int) ([]string, error) {
 	var sKeys []string
 	key, err := registry.OpenKey(r.RootKey, r.Path, registry.ENUMERATE_SUB_KEYS)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(amount) != 0 {
-		sKeys, err = key.ReadSubKeyNames(amount[0])
-	} else {
-		sKeys, err = key.ReadSubKeyNames(0)
-	}
-
+	sKeys, err = key.ReadSubKeyNames(amount)
 	if err != nil {
 		return nil, err
 	}
+
 	return sKeys, nil
 }

--- a/reggie.go
+++ b/reggie.go
@@ -152,7 +152,6 @@ func (r *Reg) CreateKey(name string) error {
 	if exists {
 		return fmt.Errorf("key %s already exists", name)
 	}
-	r.SubKeyMap = make(map[string]*SubKey)
 	r.SubKeyMap[name] = NewSubKey(r.Permission)
 	return nil
 }

--- a/reggie.go
+++ b/reggie.go
@@ -108,7 +108,8 @@ func (r *Reg) GetKeysValues() error {
 	return nil
 }
 
-// GetValue takes a specified registry key and returns the value of the named key `n`
+// GetValue takes a specified registry key and returns the value of the named key `n`.
+// This is a generic wrapper function over registry.GetValue.
 func (r *Reg) GetValue(k registry.Key, n string) (any, error) {
 	var err error
 	_, t, _ := k.GetValue(n, nil)

--- a/reggie.go
+++ b/reggie.go
@@ -56,6 +56,22 @@ func (s *SubKey) OpenKey(populateKeyValues bool) (*Reg, error) {
 	return &k, nil
 }
 
+// CreateKey creates a child key from the Reg.ActiveKey
+func (r *Reg) CreateKey(name string) error {
+	_, exists, err := registry.CreateKey(r.ActiveKey, name, r.Permission)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return fmt.Errorf("key %s already exists", name)
+	}
+	err = r.GetKeysValues()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // GetKeysValues obtains RootKey, enumerates through each subkey in given Path. Each subkey will be attached inside Reg.SubKeyMap
 // with its relevant data.
 func (r *Reg) GetKeysValues() error {
@@ -152,7 +168,6 @@ func (r *Reg) EnumerateSubKeys(amount ...int) ([]string, error) {
 
 	var sKeys []string
 	key, err := registry.OpenKey(r.RootKey, r.Path, registry.ENUMERATE_SUB_KEYS)
-
 	if err != nil {
 		return nil, err
 	}

--- a/reggie.go
+++ b/reggie.go
@@ -21,18 +21,18 @@ type SubKey struct {
 	Value map[string]any // Holds the key value data stored in each subkey.
 }
 
-// NewReg initialises a Reg struct with ALL_ACCESS permissions. Better used for testing unless requirements demand it.
-func NewReg() *Reg {
+// NewReg initialises a Reg struct with given permissions.
+func NewReg(permission uint32) *Reg {
 	return &Reg{
-		Permission: registry.ALL_ACCESS,
+		Permission: permission,
 		SubKeys:    make(map[string]*SubKey),
 	}
 }
 
 // NewSubKey initialises a struct for Reg.SubKeys. Useful if you need to handle your own structure if traversing.
-func NewSubKey() *SubKey {
+func NewSubKey(permission uint32) *SubKey {
 	return &SubKey{
-		Key:   NewReg(),
+		Key:   NewReg(permission),
 		Value: make(map[string]any),
 	}
 }
@@ -74,7 +74,7 @@ func (r *Reg) GetKeysValues() error {
 		}
 
 		if r.SubKeys[subkey] == nil {
-			r.SubKeys[subkey] = NewSubKey()
+			r.SubKeys[subkey] = NewSubKey(r.Permission)
 		}
 
 		names, err := key.ReadValueNames(0)

--- a/reggie.go
+++ b/reggie.go
@@ -152,6 +152,9 @@ func (r *Reg) CreateKey(name string) error {
 	if exists {
 		return fmt.Errorf("key %s already exists", name)
 	}
+	if r.SubKeyMap == nil {
+		r.SubKeyMap = make(map[string]*SubKey)
+	}
 	r.SubKeyMap[name] = NewSubKey(r.Permission)
 	return nil
 }

--- a/reggie.go
+++ b/reggie.go
@@ -150,12 +150,10 @@ func (r *Reg) CreateKey(name string) error {
 		return err
 	}
 	if exists {
-		return fmt.Errorf("key %s already exists", name)
+		return fmt.Errorf("key %r already exists", name)
 	}
-	err = r.GetKeysValues() // Repopulate struct with new keys
-	if err != nil {
-		return err
-	}
+	r.SubKeyMap = make(map[string]*SubKey)
+	r.SubKeyMap[name] = NewSubKey(r.Permission)
 	return nil
 }
 

--- a/reggie.go
+++ b/reggie.go
@@ -150,7 +150,7 @@ func (r *Reg) CreateKey(name string) error {
 		return err
 	}
 	if exists {
-		return fmt.Errorf("key %r already exists", name)
+		return fmt.Errorf("key %s already exists", name)
 	}
 	r.SubKeyMap = make(map[string]*SubKey)
 	r.SubKeyMap[name] = NewSubKey(r.Permission)

--- a/reggie.go
+++ b/reggie.go
@@ -178,7 +178,7 @@ func (r *Reg) CreateValue(key string, value any, valueType uint32) error {
 		err = r.ActiveKey.SetExpandStringValue(key, value.(string))
 	case registry.MULTI_SZ:
 		if _, ok := value.(string); !ok {
-			err = fmt.Errorf[]("value is not of type string but of type: %T", value)
+			err = fmt.Errorf("value is not of type string but of type: %T", value)
 			break
 		}
 		err = r.ActiveKey.SetStringsValue(key, value.([]string))

--- a/reggie.go
+++ b/reggie.go
@@ -165,16 +165,40 @@ func (r *Reg) CreateValue(key string, value any, valueType uint32) error {
 
 	switch valueType {
 	case registry.SZ:
+		if _, ok := value.(string); !ok {
+			err = fmt.Errorf("value is not of type string but of type: %T", value)
+			break
+		}
 		err = r.ActiveKey.SetStringValue(key, value.(string))
 	case registry.EXPAND_SZ:
+		if _, ok := value.(string); !ok {
+			err = fmt.Errorf("value is not of type string but of type: %T", value)
+			break
+		}
 		err = r.ActiveKey.SetExpandStringValue(key, value.(string))
 	case registry.MULTI_SZ:
+		if _, ok := value.(string); !ok {
+			err = fmt.Errorf[]("value is not of type string but of type: %T", value)
+			break
+		}
 		err = r.ActiveKey.SetStringsValue(key, value.([]string))
 	case registry.BINARY:
+		if _, ok := value.([]byte); !ok {
+			err = fmt.Errorf("value is not of type []byte but of type: %T", value)
+			break
+		}
 		err = r.ActiveKey.SetBinaryValue(key, value.([]byte))
 	case registry.QWORD:
+		if _, ok := value.(uint64); !ok {
+			err = fmt.Errorf("value is not of type uint64 but of type: %T", value)
+			break
+		}
 		err = r.ActiveKey.SetQWordValue(key, value.(uint64))
 	case registry.DWORD:
+		if _, ok := value.(uint32); !ok {
+			err = fmt.Errorf("value is not of type uint32 but of type: %T", value)
+			break
+		}
 		err = r.ActiveKey.SetDWordValue(key, value.(uint32))
 	}
 

--- a/reggie.go
+++ b/reggie.go
@@ -111,8 +111,8 @@ func (r *Reg) GetKeysValues() error {
 // This is a generic wrapper function over registry.GetValue.
 func (r *Reg) GetValue(k registry.Key, n string) (any, error) {
 	var err error
-	_, t, _ := k.GetValue(n, nil)
 	var v any
+	_, t, _ := k.GetValue(n, nil)
 
 	switch t {
 	case registry.NONE:

--- a/reggie.go
+++ b/reggie.go
@@ -55,10 +55,10 @@ func (s *SubKey) OpenKey(populateKeyValues bool) (*Reg, error) {
 	return &k, nil
 }
 
-// GetKeysValues obtains RootKey, enumerates through each subkey in given Path. Each subkey will be attached inside Reg.SubKeyMap
+// GetKeysValues obtains RootKey, enumerates through every subkey in given Path. Each subkey will be attached inside Reg.SubKeyMap
 // with its relevant data.
 func (r *Reg) GetKeysValues() error {
-	s, err := r.EnumerateSubKeys()
+	s, err := r.EnumerateSubKeys(0)
 	if err != nil {
 		return err
 	}

--- a/reggie.go
+++ b/reggie.go
@@ -159,15 +159,23 @@ func (r *Reg) CreateKey(name string) error {
 	return nil
 }
 
-// CreateStringValue will create a String key=value pair or expanded string key=value pair inside the passed Reg.ActiveKey
-func (r *Reg) CreateStringValue(key string, value string, stringType uint32) error {
+// CreateValue will create a designated key=value pair based on the valueType passed from registry type constants
+func (r *Reg) CreateValue(key string, value any, valueType uint32) error {
 	var err error
 
-	switch stringType {
+	switch valueType {
 	case registry.SZ:
-		err = r.ActiveKey.SetStringValue(key, value)
+		err = r.ActiveKey.SetStringValue(key, value.(string))
 	case registry.EXPAND_SZ:
-		err = r.ActiveKey.SetExpandStringValue(key, value)
+		err = r.ActiveKey.SetExpandStringValue(key, value.(string))
+	case registry.MULTI_SZ:
+		err = r.ActiveKey.SetStringsValue(key, value.([]string))
+	case registry.BINARY:
+		err = r.ActiveKey.SetBinaryValue(key, value.([]byte))
+	case registry.QWORD:
+		err = r.ActiveKey.SetQWordValue(key, value.(uint64))
+	case registry.DWORD:
+		err = r.ActiveKey.SetDWordValue(key, value.(uint32))
 	}
 	if err != nil {
 		return err

--- a/reggie.go
+++ b/reggie.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package reggie
 
 import (
@@ -8,9 +10,9 @@ import (
 
 type Reg struct {
 	RootKey    registry.Key // The key in which to access (HKLM, HKCU, etc). Can also be a subkey
-	Path       string       // The path inside RootKey to use
-	Permission uint32       // The access type for given RootKey and Path
 	OpenedKey  registry.Key
+	Path       string             // The path inside RootKey to use
+	Permission uint32             // The access type for given RootKey and Path
 	SubKeys    map[string]*SubKey // Holds the subkeys underneath RootKey
 }
 
@@ -19,7 +21,21 @@ type SubKey struct {
 	Value map[string]any // Holds the key value data stored in each subkey.
 }
 
-var regStr []*Reg
+// NewReg initialises a Reg struct with ALL_ACCESS permissions. Better used for testing unless requirements demand it.
+func NewReg() *Reg {
+	return &Reg{
+		Permission: registry.ALL_ACCESS,
+		SubKeys:    make(map[string]*SubKey),
+	}
+}
+
+// NewSubKey initialises a struct for Reg.SubKeys. Useful if you need to handle your own structure if traversing.
+func NewSubKey() *SubKey {
+	return &SubKey{
+		Key:   NewReg(),
+		Value: make(map[string]any),
+	}
+}
 
 // OpenKey is used to open a key inside the SubKey struct. Parameter `populateKeyValues` is true or false if you
 // want to populate the SubKeys map with the subkeys data.
@@ -42,14 +58,6 @@ func (s *SubKey) OpenKey(populateKeyValues bool) (*Reg, error) {
 	return &k, nil
 }
 
-// New initialises a Reg struct with ALL_ACCESS permissions. Better used for testing unless requirements demand it.
-func New() *Reg {
-	return &Reg{
-		Permission: registry.ALL_ACCESS,
-		SubKeys:    make(map[string]*SubKey),
-	}
-}
-
 // GetKeysValues obtains RootKey, enumerates through each subkey in given Path. Each subkey will be attached inside Reg.SubKeys
 // with its relevant data.
 func (r *Reg) GetKeysValues() error {
@@ -57,22 +65,23 @@ func (r *Reg) GetKeysValues() error {
 	if err != nil {
 		return err
 	}
+
 	for _, subkey := range s {
 		p := r.Path + "\\" + subkey
 		key, err := registry.OpenKey(r.RootKey, p, r.Permission) // Must open each subkey as a new key
 		if err != nil {
 			return err
 		}
+
 		if r.SubKeys[subkey] == nil {
-			r.SubKeys[subkey] = &SubKey{
-				Key:   &Reg{},
-				Value: make(map[string]any),
-			}
+			r.SubKeys[subkey] = NewSubKey()
 		}
+
 		names, err := key.ReadValueNames(0)
 		if err != nil {
 			return err
 		}
+
 		for _, n := range names {
 			value, err := r.GetValueFromType(key, n)
 			if err != nil {
@@ -80,6 +89,7 @@ func (r *Reg) GetKeysValues() error {
 			}
 			r.SubKeys[subkey].Value[n] = value
 		}
+
 		r.SubKeys[subkey].Key.Path = p
 		r.SubKeys[subkey].Key.OpenedKey = key
 		r.SubKeys[subkey].Key.RootKey = r.RootKey
@@ -93,6 +103,7 @@ func (r *Reg) GetValueFromType(k registry.Key, n string) (any, error) {
 	var err error
 	_, t, _ := k.GetValue(n, nil)
 	var v any
+
 	switch t {
 	case registry.NONE:
 		return nil, nil // Allow nil checks
@@ -108,9 +119,11 @@ func (r *Reg) GetValueFromType(k registry.Key, n string) (any, error) {
 	case registry.MULTI_SZ:
 		v, _, err = k.GetStringsValue(n)
 	}
+
 	if err != nil {
 		return nil, err
 	}
+
 	return v, nil
 }
 
@@ -122,16 +135,20 @@ func (r *Reg) EnumerateSubKeys(amount ...int) ([]string, error) {
 	if len(amount) > 1 {
 		return nil, errors.New("length of amount cannot exceed 1")
 	}
+
 	var sKeys []string
 	key, err := registry.OpenKey(r.RootKey, r.Path, registry.ENUMERATE_SUB_KEYS)
+
 	if err != nil {
 		return nil, err
 	}
+
 	if len(amount) != 0 {
 		sKeys, err = key.ReadSubKeyNames(amount[0])
 	} else {
 		sKeys, err = key.ReadSubKeyNames(0)
 	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -143,13 +160,16 @@ func Traverse(r *Reg, getKeyValues bool, fn func(reg *Reg)) error {
 	if fn == nil {
 		return fmt.Errorf("function is nil, traversal cannot continue")
 	}
+
 	for _, s := range r.SubKeys {
 		r, err := s.OpenKey(getKeyValues)
 		if err != nil {
 			return err
 		}
+
 		fn(r)
 		_ = Traverse(r, getKeyValues, fn)
 	}
+
 	return nil
 }

--- a/reggie.go
+++ b/reggie.go
@@ -103,7 +103,6 @@ func (r *Reg) GetKeysValues() error {
 				r.SubKeyMap[subkey].Value[n] = value
 			}
 		}
-
 	}
 	return nil
 }
@@ -229,6 +228,17 @@ func (r *Reg) EnumerateSubKeys(amount int) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return sKeys, nil
+}
+
+func (r *Reg) Close() (bool, error) {
+	err := r.ActiveKey.Close()
+	if err != nil {
+		return false, err
+	}
+	err = r.RootKey.Close()
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/reggie.go
+++ b/reggie.go
@@ -90,12 +90,14 @@ func (r *Reg) GetKeysValues() error {
 			}
 			r.SubKeys[subkey].Value[n] = value
 		}
+
 		r.SubKeys[subkey].Key = &Reg{
 			Path:       p,
 			RootKey:    r.RootKey,
 			OpenedKey:  key,
 			Permission: r.Permission,
 		}
+
 	}
 	return nil
 }
@@ -109,15 +111,20 @@ func (r *Reg) GetValueFromType(k registry.Key, n string) (any, error) {
 	switch t {
 	case registry.NONE:
 		return nil, nil // Allow nil checks
+
 	case registry.SZ:
 		v, _, err = k.GetStringValue(n)
+
 	case registry.EXPAND_SZ:
 		v, _, err = k.GetStringValue(n)
 		v, err = registry.ExpandString(v.(string))
+
 	case registry.DWORD, registry.QWORD:
 		v, _, err = k.GetIntegerValue(n)
+
 	case registry.BINARY:
 		v, _, err = k.GetBinaryValue(n)
+
 	case registry.MULTI_SZ:
 		v, _, err = k.GetStringsValue(n)
 	}

--- a/reggie.go
+++ b/reggie.go
@@ -177,13 +177,16 @@ func (r *Reg) CreateValue(key string, value any, valueType uint32) error {
 	case registry.DWORD:
 		err = r.ActiveKey.SetDWordValue(key, value.(uint32))
 	}
+
 	if err != nil {
 		return err
 	}
+
 	err = r.GetKeysValues()
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/reggie.go
+++ b/reggie.go
@@ -240,5 +240,6 @@ func (r *Reg) Close() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	clear(r.SubKeyMap)
 	return true, nil
 }

--- a/util.go
+++ b/util.go
@@ -1,0 +1,24 @@
+package reggie
+
+import (
+	"fmt"
+)
+
+// Traverse allows you to recursively traverse a given reg object based on its current key.
+func Traverse(r *Reg, getKeyValues bool, fn func(reg *Reg)) error {
+	if fn == nil {
+		return fmt.Errorf("function is nil, traversal cannot continue")
+	}
+
+	for _, s := range r.SubKeyMap {
+		r, err := s.OpenKey(getKeyValues)
+		if err != nil {
+			return err
+		}
+
+		fn(r)
+		_ = Traverse(r, getKeyValues, fn)
+	}
+
+	return nil
+}


### PR DESCRIPTION
**Changes**
- Rename `GetKeysValues` to `FillKeysValues`
- Add `NewSubKey`, CreateStringValue` `Close` `CreateKey` functions
- Formatted errors for various functions
- Move `Traverse` func to `util`
- Type assertions added for registry data types

**Fixes**
- Fix `EnumerateSubKey` func to operate the same way as the documentation states
- Fix `outer map not initialised` error when handling key subsets
- Fix `CreateValue` generics for windows types
- Fix `GetKeysValues` function to call 0 on `EnumerateSubKeys`
- Fix closing keys not clearing maps
- Correctly generate `SubKey` maps if they're nil